### PR TITLE
Fixed the bug where the tablock input gets ignored if the player happens to be moving their mouse

### DIFF
--- a/Assets/Scripts/Client/UI/persistant_core.gd
+++ b/Assets/Scripts/Client/UI/persistant_core.gd
@@ -192,7 +192,8 @@ func _on_area_2d_mouse_exited() -> void:
 
 var IsInBounds = false
 
-func _input(event: InputEvent) -> void:
+# DM:> Changing it from _input to _unhandled_key_input, fixes the bug where the tab lock mode gets ignore when the player moves the mouse cursor.
+func _unhandled_key_input(event: InputEvent) -> void:
 	if Input.is_action_just_pressed("shiftlock") && !Mouse_In_UI:
 		TablockEnabled = !TablockEnabled
 

--- a/project.godot
+++ b/project.godot
@@ -28,7 +28,7 @@ window/size/viewport_height=600
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/EasySpaceNodes/plugin.cfg", "res://addons/anthonyec.camera_preview/plugin.cfg", "res://addons/jwt/plugin.cfg")
+enabled=PackedStringArray("res://addons/EasySpaceNodes/plugin.cfg", "res://addons/jwt/plugin.cfg")
 
 [file_customization]
 


### PR DESCRIPTION
This pull request fixes an issue where the input for entering and exiting tablock seemingly gets ignored if the player is moving their mouse cursor.